### PR TITLE
fix: give the publish-image workflow runs-on parameter a right input

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ github.event.inputs.imageName }}
+    runs-on: ${{ github.event.inputs.runOn }}
     permissions:
       contents: read
       packages: write

--- a/images/Dockerfile.ubuntu-22.04-rust
+++ b/images/Dockerfile.ubuntu-22.04-rust
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 FROM ubuntu:22.04
 
 ARG TARGETPLATFORM


### PR DESCRIPTION
minor change: delete unused line in `Dockerfile.ubuntu-22.04-rust`.