### PR TITLE
 chore: Do not install zstd and support for manually specifying image tag

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -17,6 +17,9 @@ on:
       imageName:
         type: string
         description: The name of the image
+      imageTag:
+        type: string
+        description: The tag of the image
       runsOn:
         type: string
         description: The environment that this job runs on, such ubuntu-latest
@@ -95,7 +98,7 @@ jobs:
             linux/amd64
           tags: |
             ${{ vars.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image.outputs.version }}
-            ${{ vars.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ vars.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.imageTag }}
           build-args: |
             RUNNER_VERSION=${{ steps.image.outputs.version }}
             TARGETPLATFORM=${{ github.event.inputs.targetPlatform }}

--- a/.github/workflows/publish-windows-image.yml
+++ b/.github/workflows/publish-windows-image.yml
@@ -9,6 +9,9 @@ on:
       imageName:
         type: string
         description: The name of the image
+      imageTag:
+        type: string
+        description: The tag of the image
       runsOn:
         type: string
         description: The environment that this job runs on, such windows-2022
@@ -53,7 +56,7 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Build image
-        run: docker build -t ${{ vars.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image.outputs.version }} -f images/Dockerfile.${{ github.event.inputs.imageName }} --build-arg RUNNER_VERSION=${{ github.event.inputs.runnerVersion }} images
+        run: docker build -t ${{ vars.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image.outputs.version }} -t ${{ vars.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.imageTag }} -f images/Dockerfile.${{ github.event.inputs.imageName }} --build-arg RUNNER_VERSION=${{ github.event.inputs.runnerVersion }} images
       - name: Add Tag
         run: docker tag ${{ vars.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image.outputs.version }} ${{ vars.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
       - name: Push image

--- a/images/Dockerfile.ubuntu-22.04
+++ b/images/Dockerfile.ubuntu-22.04
@@ -63,7 +63,7 @@ RUN apt-get update -y \
     jq \
     sudo \
     iptables \
-    zstd \
+    # zstd \
     && rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64

--- a/images/Dockerfile.ubuntu-22.04-physical
+++ b/images/Dockerfile.ubuntu-22.04-physical
@@ -63,7 +63,7 @@ RUN apt-get update -y \
     jq \
     sudo \
     iptables \
-    zstd \
+    # zstd \
     && rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64

--- a/images/Dockerfile.ubuntu-24.04
+++ b/images/Dockerfile.ubuntu-24.04
@@ -63,7 +63,7 @@ RUN apt-get update -y \
     jq \
     sudo \
     iptables \
-    zstd \
+    # zstd \
     && rm -rf /var/lib/apt/lists/*
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64


### PR DESCRIPTION
1. Do not install zstd for the time being,
because the cache plugin will use zstd by default to decompress the retained cache,
which will lead to failure.

2. When creating the image, remove the "latest" tag to avoid accidental use.
 Add support for manually specifying tags to facilitate debugging new images.