### PR TITLE
chore: Optimize cache utilization

### DIFF
--- a/images/Dockerfile.ubuntu-22.04
+++ b/images/Dockerfile.ubuntu-22.04
@@ -85,30 +85,13 @@ RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner \
 ENV HOME=/home/runner
 WORKDIR /home/runner
 
-ARG RUNNER_VERSION
-ARG DUMB_INIT_VERSION=1.2.5
-
 ARG TARGETPLATFORM
+ARG DUMB_INIT_VERSION=1.2.5
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
     && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
     && chmod +x /usr/bin/dumb-init
-
-ENV RUNNER_ASSETS_DIR=/home/runner
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x64 ; fi \
-    && mkdir -p "$RUNNER_ASSETS_DIR" \
-    && cd "$RUNNER_ASSETS_DIR" \
-    && curl -fLo runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \
-    && tar xzf ./runner.tar.gz \
-    && rm runner.tar.gz \
-    && ./bin/installdependencies.sh \
-    # libyaml-dev is required for ruby/setup-ruby action.
-    # It is installed after installdependencies.sh and before removing /var/lib/apt/lists
-    # to avoid rerunning apt-update on its own.
-    && apt-get install -y libyaml-dev \
-    && rm -rf /var/lib/apt/lists/*
 
 # Prepare tool cache
 ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
@@ -117,11 +100,6 @@ RUN mkdir ${RUNNER_TOOL_CACHE} \
     && chmod g+rwx ${RUNNER_TOOL_CACHE}
 ARG HOST_TMP_TOOL_CACHE
 COPY --chown=$RUNNER_USER_UID:$RUNNER_USER_UID ./$HOST_TMP_TOOL_CACHE/ $RUNNER_TOOL_CACHE/
-
-RUN cd "$RUNNER_ASSETS_DIR" \
-    && curl -fLo runner-container-hooks.zip https://github.com/lynx-infra/runner-container-hooks/releases/download/v0.7.0-patch.0/actions-runner-hooks-k8s-0.7.0-patch.0.zip \
-    && unzip ./runner-container-hooks.zip -d ./k8s \
-    && rm -f runner-container-hooks.zip
 
 # Docker Buildx and Docker Compose
 ARG CHANNEL=stable
@@ -183,7 +161,6 @@ ENV PATH $PATH:$ANDROID_HOME/cmdline-tools/bin
 
 ENV PATH $PATH:$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/share/clang:$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/emulator
 
-
 # Accept license
 RUN yes | sdkmanager --licenses --sdk_root=$ANDROID_HOME
 # Install android sdk
@@ -208,6 +185,28 @@ RUN echo "PATH=${PATH}" > /etc/environment \
     && echo "ImageOS=${ImageOS}" >> /etc/environment
 
 RUN ln -s $ANDROID_HOME $ANDROID_HOME/SDK
+
+# Prepare runner app
+ARG RUNNER_VERSION
+ENV RUNNER_ASSETS_DIR=/home/runner
+RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
+    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x64 ; fi \
+    && mkdir -p "$RUNNER_ASSETS_DIR" \
+    && cd "$RUNNER_ASSETS_DIR" \
+    && curl -fLo runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \
+    && tar xzf ./runner.tar.gz \
+    && rm runner.tar.gz \
+    && ./bin/installdependencies.sh \
+    # libyaml-dev is required for ruby/setup-ruby action.
+    # It is installed after installdependencies.sh and before removing /var/lib/apt/lists
+    # to avoid rerunning apt-update on its own.
+    && apt-get install -y libyaml-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cd "$RUNNER_ASSETS_DIR" \
+    && curl -fLo runner-container-hooks.zip https://github.com/lynx-infra/runner-container-hooks/releases/download/v0.7.0-patch.0/actions-runner-hooks-k8s-0.7.0-patch.0.zip \
+    && unzip ./runner-container-hooks.zip -d ./k8s \
+    && rm -f runner-container-hooks.zip
 
 USER runner
 

--- a/images/Dockerfile.ubuntu-22.04-physical
+++ b/images/Dockerfile.ubuntu-22.04-physical
@@ -85,31 +85,13 @@ RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner \
 ENV HOME=/home/runner
 WORKDIR /home/runner
 
-ARG RUNNER_VERSION
-ARG RUNNER_CONTAINER_HOOKS_VERSION=0.6.1
-ARG DUMB_INIT_VERSION=1.2.5
-
 ARG TARGETPLATFORM
+ARG DUMB_INIT_VERSION=1.2.5
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
     && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
     && chmod +x /usr/bin/dumb-init
-
-ENV RUNNER_ASSETS_DIR=/home/runner
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x64 ; fi \
-    && mkdir -p "$RUNNER_ASSETS_DIR" \
-    && cd "$RUNNER_ASSETS_DIR" \
-    && curl -fLo runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \
-    && tar xzf ./runner.tar.gz \
-    && rm runner.tar.gz \
-    && ./bin/installdependencies.sh \
-    # libyaml-dev is required for ruby/setup-ruby action.
-    # It is installed after installdependencies.sh and before removing /var/lib/apt/lists
-    # to avoid rerunning apt-update on its own.
-    && apt-get install -y libyaml-dev \
-    && rm -rf /var/lib/apt/lists/*
 
 # Prepare tool cache
 ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
@@ -118,11 +100,6 @@ RUN mkdir ${RUNNER_TOOL_CACHE} \
     && chmod g+rwx ${RUNNER_TOOL_CACHE}
 ARG HOST_TMP_TOOL_CACHE
 COPY --chown=$RUNNER_USER_UID:$RUNNER_USER_UID ./$HOST_TMP_TOOL_CACHE/ $RUNNER_TOOL_CACHE/
-
-RUN cd "$RUNNER_ASSETS_DIR" \
-    && curl -fLo runner-container-hooks.zip https://github.com/actions/runner-container-hooks/releases/download/v${RUNNER_CONTAINER_HOOKS_VERSION}/actions-runner-hooks-k8s-${RUNNER_CONTAINER_HOOKS_VERSION}.zip \
-    && unzip ./runner-container-hooks.zip -d ./k8s \
-    && rm -f runner-container-hooks.zip
 
 # Docker Buildx and Docker Compose
 ARG CHANNEL=stable
@@ -209,6 +186,28 @@ RUN echo "PATH=${PATH}" > /etc/environment \
     && echo "ImageOS=${ImageOS}" >> /etc/environment
 
 RUN ln -s $ANDROID_HOME $ANDROID_HOME/SDK
+
+# Prepare runner app
+ARG RUNNER_VERSION
+ENV RUNNER_ASSETS_DIR=/home/runner
+RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
+    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x64 ; fi \
+    && mkdir -p "$RUNNER_ASSETS_DIR" \
+    && cd "$RUNNER_ASSETS_DIR" \
+    && curl -fLo runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \
+    && tar xzf ./runner.tar.gz \
+    && rm runner.tar.gz \
+    && ./bin/installdependencies.sh \
+    # libyaml-dev is required for ruby/setup-ruby action.
+    # It is installed after installdependencies.sh and before removing /var/lib/apt/lists
+    # to avoid rerunning apt-update on its own.
+    && apt-get install -y libyaml-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cd "$RUNNER_ASSETS_DIR" \
+    && curl -fLo runner-container-hooks.zip https://github.com/lynx-infra/runner-container-hooks/releases/download/v0.7.0-patch.0/actions-runner-hooks-k8s-0.7.0-patch.0.zip \
+    && unzip ./runner-container-hooks.zip -d ./k8s \
+    && rm -f runner-container-hooks.zip
 
 # Add runner to rdma group because of /dev/kvm
 RUN usermod -aG rdma runner

--- a/images/Dockerfile.ubuntu-24.04
+++ b/images/Dockerfile.ubuntu-24.04
@@ -85,31 +85,13 @@ RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner \
 ENV HOME=/home/runner
 WORKDIR /home/runner
 
-ARG RUNNER_VERSION
-ARG RUNNER_CONTAINER_HOOKS_VERSION=0.6.1
-ARG DUMB_INIT_VERSION=1.2.5
-
 ARG TARGETPLATFORM
+ARG DUMB_INIT_VERSION=1.2.5
 RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
     && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
     && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x86_64 ; fi \
     && curl -fLo /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_${ARCH} \
     && chmod +x /usr/bin/dumb-init
-
-ENV RUNNER_ASSETS_DIR=/home/runner
-RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x64 ; fi \
-    && mkdir -p "$RUNNER_ASSETS_DIR" \
-    && cd "$RUNNER_ASSETS_DIR" \
-    && curl -fLo runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \
-    && tar xzf ./runner.tar.gz \
-    && rm runner.tar.gz \
-    && ./bin/installdependencies.sh \
-    # libyaml-dev is required for ruby/setup-ruby action.
-    # It is installed after installdependencies.sh and before removing /var/lib/apt/lists
-    # to avoid rerunning apt-update on its own.
-    && apt-get install -y libyaml-dev \
-    && rm -rf /var/lib/apt/lists/*
 
 # Prepare tool cache
 ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
@@ -118,11 +100,6 @@ RUN mkdir ${RUNNER_TOOL_CACHE} \
     && chmod g+rwx ${RUNNER_TOOL_CACHE}
 ARG HOST_TMP_TOOL_CACHE
 COPY --chown=$RUNNER_USER_UID:$RUNNER_USER_UID ./$HOST_TMP_TOOL_CACHE/ $RUNNER_TOOL_CACHE/
-
-RUN cd "$RUNNER_ASSETS_DIR" \
-    && curl -fLo runner-container-hooks.zip https://github.com/actions/runner-container-hooks/releases/download/v${RUNNER_CONTAINER_HOOKS_VERSION}/actions-runner-hooks-k8s-${RUNNER_CONTAINER_HOOKS_VERSION}.zip \
-    && unzip ./runner-container-hooks.zip -d ./k8s \
-    && rm -f runner-container-hooks.zip
 
 # Docker Buildx and Docker Compose
 ARG CHANNEL=stable
@@ -206,6 +183,28 @@ RUN echo "PATH=${PATH}" > /etc/environment \
     && echo "ImageOS=${ImageOS}" >> /etc/environment
 
 RUN ln -s $ANDROID_HOME $ANDROID_HOME/SDK
+
+# Prepare runner app
+ARG RUNNER_VERSION
+ENV RUNNER_ASSETS_DIR=/home/runner
+RUN export ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
+    && if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "i386" ]; then export ARCH=x64 ; fi \
+    && mkdir -p "$RUNNER_ASSETS_DIR" \
+    && cd "$RUNNER_ASSETS_DIR" \
+    && curl -fLo runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \
+    && tar xzf ./runner.tar.gz \
+    && rm runner.tar.gz \
+    && ./bin/installdependencies.sh \
+    # libyaml-dev is required for ruby/setup-ruby action.
+    # It is installed after installdependencies.sh and before removing /var/lib/apt/lists
+    # to avoid rerunning apt-update on its own.
+    && apt-get install -y libyaml-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cd "$RUNNER_ASSETS_DIR" \
+    && curl -fLo runner-container-hooks.zip https://github.com/lynx-infra/runner-container-hooks/releases/download/v0.7.0-patch.0/actions-runner-hooks-k8s-0.7.0-patch.0.zip \
+    && unzip ./runner-container-hooks.zip -d ./k8s \
+    && rm -f runner-container-hooks.zip
 
 USER runner
 


### PR DESCRIPTION
 Optimize cache utilization by moving runner app installation to the end of the Dockerfile

Relocating the runner app installation steps to the tail of the Dockerfile maximizes the reuse of cached layers for earlier operations (such as base image setup, dependency installation, and environment configuration). This not only reduces redundant rebuilds when only the runner app code or installation logic changes but also accelerates image pulls—since unchanged layers can be fetched from local caches instead of being re-downloaded. This optimization enhances efficiency across both build and distribution workflows.