### PR TITLE
chore: ubuntu add libc6-dbg

### DIFF
--- a/images/Dockerfile.ubuntu-24.04
+++ b/images/Dockerfile.ubuntu-24.04
@@ -63,6 +63,7 @@ RUN apt-get update -y \
     jq \
     sudo \
     iptables \
+    libc6-dbg \
     # zstd \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
ubuntu add libc6-dbg
because of valgrind-codspeed.deb fail