### PR TITLE
chore:update actions because of  Node.js 24

### DIFF
--- a/.github/workflows/publish-linux-image.yml
+++ b/.github/workflows/publish-linux-image.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Generate matrix based on input
         id: generate-matrix
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         env:
           INPUT_IMAGENAME: ${{ github.event.inputs.imageName }}
         with:
@@ -88,7 +88,7 @@ jobs:
           mkdir -p "${{ runner.tool_cache }}"
 
       - name: Setup Python for toolcache
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_TOOLCACHE_VERSION }}
 
@@ -99,7 +99,7 @@ jobs:
           tar -czf tool_cache_${{ matrix.distro }}.tar.gz *
 
       - name: Upload tool cache artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: toolcache-${{ matrix.distro }}
           path: ${{ runner.tool_cache }}/tool_cache_${{ matrix.distro }}.tar.gz
@@ -123,12 +123,12 @@ jobs:
           echo "Matrix context: ${{ toJSON(matrix) }}"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Download tool cache artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: toolcache-${{ matrix.distro }}
           path: ./toolcache_artifact
@@ -140,7 +140,7 @@ jobs:
 
       - name: Compute image version
         id: image
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         env:
           RUNNER_VERSION: ${{ github.event.inputs.runnerVersion }}
         with:
@@ -157,10 +157,10 @@ jobs:
             core.setOutput('version', runnerVersion);
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into registry ${{ vars.REGISTRY }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{ vars.REGISTRY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -169,7 +169,7 @@ jobs:
       - name: Build and push Docker image
         if: ${{ github.event.inputs.imageName == 'all' || github.event.inputs.imageName == matrix.imageName }}
         id: build-and-push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./images
           file: ./images/Dockerfile.${{ matrix.imageName }}

--- a/.github/workflows/publish-windows-image.yml
+++ b/.github/workflows/publish-windows-image.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo "${{ toJSON(github.event.inputs) }}"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.branch }}
 


### PR DESCRIPTION
Node.js 20 actions are deprecated. Some actions are running on Node.js 20 and may not work as expected Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/