### PR TITLE
fix: update python version to 3.13.14

### DIFF
--- a/.github/workflows/publish-linux-image.yml
+++ b/.github/workflows/publish-linux-image.yml
@@ -29,7 +29,7 @@ on:
 
 env:
   HOST_TMP_TOOL_CACHE: hosttmptoolcache
-  PYTHON_TOOLCACHE_VERSION: '3.13.3'
+  PYTHON_TOOLCACHE_VERSION: '3.13.14'
 
 jobs:
   select-matrix:


### PR DESCRIPTION
Version 3.13.3 was not found in the local cache
Error: The version '3.13.3' with architecture 'x64' was not found for Ubuntu 26.04. The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json