### PR TITLE
fix: use ubuntu 24.04 to build 26.04

### DIFF
--- a/.github/workflows/publish-linux-image.yml
+++ b/.github/workflows/publish-linux-image.yml
@@ -52,7 +52,8 @@ jobs:
             const allConfigs = [
               { imageName: 'ubuntu-22.04', runs_on: 'raw-ubuntu-22.04', distro: 'ubuntu-22.04' },
               { imageName: 'ubuntu-24.04', runs_on: 'raw-ubuntu-24.04', distro: 'ubuntu-24.04' },
-              { imageName: 'ubuntu-26.04', runs_on: 'raw-ubuntu-26.04', distro: 'ubuntu-26.04' }
+              // Reuse the Ubuntu 24.04 build host; prepare the toolcache on Ubuntu 26.04 via distro.
+              { imageName: 'ubuntu-26.04', runs_on: 'raw-ubuntu-24.04', distro: 'ubuntu-26.04' }
             ];
 
             let include = [];


### PR DESCRIPTION
cloud platform has no ubuntu 26.04 image