### PR TITLE
fix: use USTC Ubuntu mirror for Ubuntu 26.04

### DIFF
--- a/images/Dockerfile.ubuntu-26.04
+++ b/images/Dockerfile.ubuntu-26.04
@@ -4,6 +4,8 @@ ENV TZ=Asia/Shanghai \
     DEBIAN_FRONTEND=noninteractive
 
 ARG PYTHON_VERSION="3.12"
+COPY sources.list.ubuntu-26.04 /etc/apt/sources.list
+RUN rm -f /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources || true
 
 # 基础工具
 RUN apt-get update -y \

--- a/images/sources.list.ubuntu-26.04
+++ b/images/sources.list.ubuntu-26.04
@@ -1,14 +1,14 @@
-deb http://mirrors.ivolces.com/ubuntu/ resolute main restricted universe multiverse
-deb-src http://mirrors.ivolces.com/ubuntu/ resolute main restricted universe multiverse
+deb https://mirrors.ustc.edu.cn/ubuntu/ resolute main restricted universe multiverse
+deb-src https://mirrors.ustc.edu.cn/ubuntu/ resolute main restricted universe multiverse
 
-deb http://mirrors.ivolces.com/ubuntu/ resolute-security main restricted universe multiverse
-deb-src http://mirrors.ivolces.com/ubuntu/ resolute-security main restricted universe multiverse
+deb https://mirrors.ustc.edu.cn/ubuntu/ resolute-security main restricted universe multiverse
+deb-src https://mirrors.ustc.edu.cn/ubuntu/ resolute-security main restricted universe multiverse
 
-deb http://mirrors.ivolces.com/ubuntu/ resolute-updates main restricted universe multiverse
-deb-src http://mirrors.ivolces.com/ubuntu/ resolute-updates main restricted universe multiverse
+deb https://mirrors.ustc.edu.cn/ubuntu/ resolute-updates main restricted universe multiverse
+deb-src https://mirrors.ustc.edu.cn/ubuntu/ resolute-updates main restricted universe multiverse
 
-# deb http://mirrors.ivolces.com/ubuntu/ resolute-proposed main restricted universe multiverse
-# deb-src http://mirrors.ivolces.com/ubuntu/ resolute-proposed main restricted universe multiverse
+# deb https://mirrors.ustc.edu.cn/ubuntu/ resolute-proposed main restricted universe multiverse
+# deb-src https://mirrors.ustc.edu.cn/ubuntu/ resolute-proposed main restricted universe multiverse
 
-deb http://mirrors.ivolces.com/ubuntu/ resolute-backports main restricted universe multiverse
-deb-src http://mirrors.ivolces.com/ubuntu/ resolute-backports main restricted universe multiverse
+deb https://mirrors.ustc.edu.cn/ubuntu/ resolute-backports main restricted universe multiverse
+deb-src https://mirrors.ustc.edu.cn/ubuntu/ resolute-backports main restricted universe multiverse


### PR DESCRIPTION
## Summary

- Replace the placeholder Volcano Ubuntu 26.04 apt source with the USTC Ubuntu mirror.
- Make the Ubuntu 26.04 Dockerfile install the repo-provided sources list and remove the base image default .sources entries, matching the Ubuntu 22.04/24.04 approach.
- Do not preinstall user-specific dependencies.

## Why

The Ubuntu 26.04 self-hosted runner jobs can fail when a workflow runs apt-get update/apt-get install because the runner network cannot reach Canonical/Ubuntu official apt endpoints. Volcano does not currently provide Ubuntu 26.04 mirror content, while USTC has the resolute pockets available.

## Validation

- Verified resolute, resolute-security, resolute-updates, and resolute-backports InRelease endpoints on mirrors.ustc.edu.cn return HTTP 200.
- Ran a static assertion that Ubuntu 26.04 uses the USTC mirror, removes default apt sources, and does not add libepoxy0 preinstallation.
- Ran git diff --check.